### PR TITLE
disable autoscroll

### DIFF
--- a/lib/src/reorderable_grid.dart
+++ b/lib/src/reorderable_grid.dart
@@ -52,6 +52,7 @@ class ReorderableGrid extends StatefulWidget {
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.restorationId,
     this.clipBehavior = Clip.hardEdge,
+    this.autoScroll,
   })  : assert(itemCount >= 0),
         super(key: key);
 
@@ -120,6 +121,10 @@ class ReorderableGrid extends StatefulWidget {
   final Clip clipBehavior;
 
   final SliverGridDelegate gridDelegate;
+
+  /// Overrides if autoscrolling is enabled. Defaults to false if `physics` is
+  /// [NeverScrollableScrollPhysics]
+  final bool? autoScroll;
 
   /// The state from the closest instance of this class that encloses the given
   /// context.
@@ -258,6 +263,8 @@ class ReorderableGridState extends State<ReorderableGrid> {
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
             proxyDecorator: widget.proxyDecorator,
+            autoScroll: widget.autoScroll ??
+                widget.physics is! NeverScrollableScrollPhysics,
           ),
         ),
       ],
@@ -297,6 +304,7 @@ class SliverReorderableGrid extends StatefulWidget {
     required this.onReorder,
     required this.gridDelegate,
     this.proxyDecorator,
+    this.autoScroll = true,
   })  : assert(itemCount >= 0),
         super(key: key);
 
@@ -313,6 +321,10 @@ class SliverReorderableGrid extends StatefulWidget {
   final ReorderItemProxyDecorator? proxyDecorator;
 
   final SliverGridDelegate gridDelegate;
+
+  /// If auto scrolling is enabled. Should be disabled if associated scroll
+  /// physics are [NeverScrollableScrollPhysics]
+  final bool autoScroll;
 
   @override
   SliverReorderableGridState createState() => SliverReorderableGridState();
@@ -589,7 +601,10 @@ class SliverReorderableGridState extends State<SliverReorderableGrid>
   }
 
   Future<void> _autoScrollIfNecessary() async {
-    if (_autoScrolling || _dragInfo == null || _dragInfo!.scrollable == null) {
+    if (_autoScrolling ||
+        _dragInfo == null ||
+        _dragInfo!.scrollable == null ||
+        widget.autoScroll == false) {
       return;
     }
 

--- a/lib/src/reorderable_grid_view.dart
+++ b/lib/src/reorderable_grid_view.dart
@@ -255,6 +255,7 @@ class ReorderableGridView extends StatefulWidget {
     this.scrollController,
     this.anchor = 0.0,
     this.proxyDecorator,
+    this.autoScroll,
   })  : assert(
           children.every((Widget w) => w.key != null),
           'All children of this widget must have a key.',
@@ -304,6 +305,7 @@ class ReorderableGridView extends StatefulWidget {
     this.scrollController,
     this.anchor = 0.0,
     this.proxyDecorator,
+    this.autoScroll,
   })  : assert(itemCount >= 0),
         super(key: key);
 
@@ -345,6 +347,7 @@ class ReorderableGridView extends StatefulWidget {
     this.scrollController,
     this.anchor = 0.0,
     this.proxyDecorator,
+    this.autoScroll,
   })  : gridDelegate = SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
           mainAxisSpacing: mainAxisSpacing,
@@ -397,6 +400,7 @@ class ReorderableGridView extends StatefulWidget {
     this.scrollController,
     this.anchor = 0.0,
     this.proxyDecorator,
+    this.autoScroll,
   })  : gridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: maxCrossAxisExtent,
           mainAxisSpacing: mainAxisSpacing,
@@ -476,6 +480,10 @@ class ReorderableGridView extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
+
+  /// Overrides if autoscrolling is enabled. Defaults to false if `physics` is
+  /// [NeverScrollableScrollPhysics]
+  final bool? autoScroll;
 
   @override
   _ReorderableGridViewState createState() => _ReorderableGridViewState();
@@ -625,6 +633,8 @@ class _ReorderableGridViewState extends State<ReorderableGridView> {
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
             proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
+            autoScroll: widget.autoScroll ??
+                widget.physics is! NeverScrollableScrollPhysics,
           ),
         ),
       ],


### PR DESCRIPTION
This PR automatically disables autoscrolling if `physics` are `NeverScrollableScrollPhysics`. It also allows the developer to override this automatic behavior using the `autoScroll` argument on `ReorderableGrid`, `SliverReorderableGrid`, and `ReorderableGridView`

### Issues

Resolves https://github.com/casvanluijtelaar/reorderable_grid/issues/10

### Code


```dart
return ReorderableGrid(
  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
    crossAxisCount: widget.layout.crossAxisCount,
    childAspectRatio: widget.layout.childAspect,
    mainAxisSpacing: widget.layout.gap,
    crossAxisSpacing: widget.layout.gap,
  ),
  itemCount: 9,
  physics: const NeverScrollableScrollPhysics(), ///////////////////////
  itemBuilder: (context, i) {
    return ReorderableGridDragStartListener(
      key: ValueKey(i),
      index: i,
      child: Container(
        color: Colors.red,
        child: Text(i.toString()),
      ),
    );
  },
  onReorder: (i, j) {
    print('from $i to $j');
  },
);
```

### Before

https://user-images.githubusercontent.com/666539/172380122-a644ae1d-fda1-426f-8040-5c8e7a591591.mov

### After

https://user-images.githubusercontent.com/666539/172380210-e59b1d5b-7c03-4c71-9639-b2b396e6a97b.mov

