### PR TITLE
disable multi drag support

### DIFF
--- a/lib/src/reorderable_grid.dart
+++ b/lib/src/reorderable_grid.dart
@@ -515,6 +515,10 @@ class SliverReorderableGridState extends State<SliverReorderableGrid>
   Drag? _dragStart(Offset position) {
     assert(_dragInfo == null);
 
+    // if any items are already being dragged, ignore this dragstart
+    if(_items.values.any((e) => e.dragging)) return null;
+
+
     final _ReorderableItemState item = _items[_dragIndex!]!;
     item.dragging = true;
     item.rebuild();


### PR DESCRIPTION
resolves https://github.com/casvanluijtelaar/reorderable_grid/issues/33

The Ideal way to fix this is to extend `DragGestureRecognizer` instead of `MultiDragGestureRecognizer` so that developers themselves can implement, or prevent multidrag support. However since the current implementation relies heavily on the `onStart`, `onEnd` interfaces in `MultiDragGestureRecognizer` it would be quite a major rewrite.

A solid argument can be made that these interface should be defined in the parent `DragGestureRecognizer` or `GestureRecognizer` classes. Will need to be discussed why this wasn't done outright

For now this PR will block any dragHandling if more than one items is currently in "dragging" mode