### PR TITLE
feat(onReorderEnd): added onReorderEnd capability

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.10"
+    version: "1.0.11"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/reorderable_grid.dart
+++ b/lib/src/reorderable_grid.dart
@@ -53,6 +53,7 @@ class ReorderableGrid extends StatefulWidget {
       this.clipBehavior = Clip.hardEdge,
       this.autoScroll,
       this.onReorderStart,
+      this.onReorderEnd,
       super.key})
       : assert(itemCount >= 0);
 
@@ -76,6 +77,9 @@ class ReorderableGrid extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorderStart}
   final void Function(int index)? onReorderStart;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderEnd}
+  final VoidCallback? onReorderEnd;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -309,6 +313,7 @@ class SliverReorderableGrid extends StatefulWidget {
       required this.onReorder,
       required this.gridDelegate,
       this.onReorderStart,
+      this.onReorderEnd,
       this.reverse = false,
       this.proxyDecorator,
       this.autoScroll = true,
@@ -327,6 +332,9 @@ class SliverReorderableGrid extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorderStart}
   final void Function(int index)? onReorderStart;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderEnd}
+  final VoidCallback? onReorderEnd;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -556,10 +564,12 @@ class SliverReorderableGridState extends State<SliverReorderableGrid>
   }
 
   void _dragCancel(_DragInfo item) {
+    widget.onReorderEnd?.call();
     _dragReset();
   }
 
   void _dragEnd(_DragInfo item) {
+    widget.onReorderEnd?.call();
     setState(() => _finalDropPosition = _itemOffsetAt(_insertIndex!));
   }
 

--- a/lib/src/reorderable_grid_view.dart
+++ b/lib/src/reorderable_grid_view.dart
@@ -257,6 +257,7 @@ class ReorderableGridView extends StatefulWidget {
     this.proxyDecorator,
     this.autoScroll,
     this.onReorderStart,
+    this.onReorderEnd,
     super.key,
   })  : assert(
           children.every((Widget w) => w.key != null),
@@ -307,6 +308,7 @@ class ReorderableGridView extends StatefulWidget {
       this.proxyDecorator,
       this.autoScroll,
       this.onReorderStart,
+      this.onReorderEnd,
       super.key})
       : assert(itemCount >= 0);
 
@@ -349,6 +351,7 @@ class ReorderableGridView extends StatefulWidget {
     this.proxyDecorator,
     this.autoScroll,
     this.onReorderStart,
+    this.onReorderEnd,
     super.key,
   })  : gridDelegate = SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
@@ -402,6 +405,7 @@ class ReorderableGridView extends StatefulWidget {
     this.proxyDecorator,
     this.autoScroll,
     this.onReorderStart,
+    this.onReorderEnd,
     super.key,
   })  : gridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: maxCrossAxisExtent,
@@ -481,6 +485,9 @@ class ReorderableGridView extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorderStart}
   final void Function(int index)? onReorderStart;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderEnd}
+  final VoidCallback? onReorderEnd;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -641,6 +648,7 @@ class ReorderableGridViewState extends State<ReorderableGridView> {
             itemCount: widget.itemCount,
             onReorder: widget.onReorder,
             onReorderStart: widget.onReorderStart,
+            onReorderEnd: widget.onReorderEnd,
             proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
             autoScroll: widget.autoScroll ??
                 widget.physics is! NeverScrollableScrollPhysics,


### PR DESCRIPTION
`_dragEnd` and `_dragCancel` now trigger the added `onReorderEnd` function. Useful to actively do something on start and end of the reordering process (like triggering animations etc.)

Since `onReorderStart` yields the `_dragIndex`, we could think about if it makes sense to yield the `_insertIndex` of `dragEnd` optionally, which will not be yield on `_dragCancel`. So instead of `VoidCallback` we do `void Function(int? index)`. But this is up to you! :)

Best
Kounex