### PR TITLE
Skip items without dragEnable when dragging

### DIFF
--- a/lib/src/reorderable_grid_view.dart
+++ b/lib/src/reorderable_grid_view.dart
@@ -679,6 +679,7 @@ class ReorderableGridViewState extends State<ReorderableGridView> {
                 widget.physics is! NeverScrollableScrollPhysics,
             scrollDirection: widget.scrollDirection,
             reverse: widget.reverse,
+            itemDragEnable: widget.itemDragEnable,
           ),
         ),
       ],


### PR DESCRIPTION
Previously, non-draggable items (where itemsDragEnable is false) would still shift position during a layout reorder triggered by other items. 

I've updated the logic to pin these items in place. Does this align with expectations, or should this be configurable via a prop?